### PR TITLE
test: add db.Init smoke test

### DIFF
--- a/internal/infrastructure/db/db_test.go
+++ b/internal/infrastructure/db/db_test.go
@@ -1,0 +1,33 @@
+package db
+
+import "testing"
+
+func TestInit(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		success  bool
+		host     string
+		user     string
+		password string
+		dbName   string
+		port     string
+		sslMode  string
+	}{
+		{"failure unreachable port", false, "127.0.0.1", "user", "password", "dbname", "1", "disable"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := Init(tt.host, tt.user, tt.password, tt.dbName, tt.port, tt.sslMode)
+			if tt.success && err != nil {
+				t.Errorf("expected no error, but got %v", err)
+			}
+			if !tt.success && err == nil {
+				t.Errorf("expected error, but got nil")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add a table-driven smoke test for `db.Init` that exercises the failure path against an unreachable port
- Bring `internal/infrastructure/db` to 100% statement coverage, in line with the rest of the suite

Closes #94.

## Notes
- Mirrors the pattern already used in [workout-service](https://github.com/qkitzero/workout-service/blob/develop/internal/infrastructure/db/db_test.go); `db.Init` signatures are identical across services
- Failure path only — the success path would require a live Postgres and is not exercised here

## Test plan
- [x] `go test ./internal/infrastructure/db/... -cover` passes
- [x] Coverage for `internal/infrastructure/db` reaches 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)