### PR TITLE
update: propagate context through repositories

### DIFF
--- a/internal/application/event/usecase.go
+++ b/internal/application/event/usecase.go
@@ -46,7 +46,7 @@ func (s *eventUsecase) CreateEvent(ctx context.Context, title event.Title, descr
 	now := time.Now()
 	newEvent := event.NewEvent(event.NewEventID(), newUserID, title, description, startTime, endTime, color, now, now)
 
-	if err := s.eventRepo.Create(newEvent); err != nil {
+	if err := s.eventRepo.Create(ctx, newEvent); err != nil {
 		return nil, err
 	}
 
@@ -59,7 +59,7 @@ func (s *eventUsecase) UpdateEvent(ctx context.Context, eventID event.EventID, t
 		return nil, err
 	}
 
-	foundEvent, err := s.eventRepo.FindByID(eventID)
+	foundEvent, err := s.eventRepo.FindByID(ctx, eventID)
 	if err != nil {
 		return nil, err
 	}
@@ -80,7 +80,7 @@ func (s *eventUsecase) UpdateEvent(ctx context.Context, eventID event.EventID, t
 
 	foundEvent.Update(title, description, newStartTime, newEndTime, color)
 
-	if err := s.eventRepo.Update(foundEvent); err != nil {
+	if err := s.eventRepo.Update(ctx, foundEvent); err != nil {
 		return nil, err
 	}
 
@@ -93,7 +93,7 @@ func (s *eventUsecase) GetEvent(ctx context.Context, eventID event.EventID) (eve
 		return nil, err
 	}
 
-	foundEvent, err := s.eventRepo.FindByID(eventID)
+	foundEvent, err := s.eventRepo.FindByID(ctx, eventID)
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +116,7 @@ func (s *eventUsecase) ListEvents(ctx context.Context) ([]event.Event, error) {
 		return nil, err
 	}
 
-	events, err := s.eventRepo.FindAllByUserID(uid)
+	events, err := s.eventRepo.FindAllByUserID(ctx, uid)
 	if err != nil {
 		return nil, err
 	}
@@ -130,7 +130,7 @@ func (s *eventUsecase) DeleteEvent(ctx context.Context, eventID event.EventID) e
 		return err
 	}
 
-	foundEvent, err := s.eventRepo.FindByID(eventID)
+	foundEvent, err := s.eventRepo.FindByID(ctx, eventID)
 	if err != nil {
 		return err
 	}
@@ -139,7 +139,7 @@ func (s *eventUsecase) DeleteEvent(ctx context.Context, eventID event.EventID) e
 		return event.ErrPermissionDenied
 	}
 
-	if err := s.eventRepo.Delete(eventID); err != nil {
+	if err := s.eventRepo.Delete(ctx, eventID); err != nil {
 		return err
 	}
 

--- a/internal/application/event/usecase_test.go
+++ b/internal/application/event/usecase_test.go
@@ -48,7 +48,7 @@ func TestCreateEvent(t *testing.T) {
 			mockUserService := mocksuser.NewMockUserService(ctrl)
 			mockEventRepository := mocksevent.NewMockEventRepository(ctrl)
 			mockUserService.EXPECT().GetUser(tt.ctx).Return(tt.userID, tt.getUserErr).AnyTimes()
-			mockEventRepository.EXPECT().Create(gomock.Any(), gomock.Any()).Return(tt.createErr).AnyTimes()
+			mockEventRepository.EXPECT().Create(tt.ctx, gomock.Any()).Return(tt.createErr).AnyTimes()
 
 			u := NewEventUsecase(mockUserService, mockEventRepository)
 
@@ -102,8 +102,8 @@ func TestUpdateEvent(t *testing.T) {
 			mockEvent.EXPECT().EndTime().Return(now).AnyTimes()
 			mockEvent.EXPECT().Update(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return().AnyTimes()
 			mockEventRepository := mocksevent.NewMockEventRepository(ctrl)
-			mockEventRepository.EXPECT().FindByID(gomock.Any(), gomock.Any()).Return(mockEvent, tt.findByIDErr).AnyTimes()
-			mockEventRepository.EXPECT().Update(gomock.Any(), gomock.Any()).Return(tt.updateErr).AnyTimes()
+			mockEventRepository.EXPECT().FindByID(tt.ctx, gomock.Any()).Return(mockEvent, tt.findByIDErr).AnyTimes()
+			mockEventRepository.EXPECT().Update(tt.ctx, gomock.Any()).Return(tt.updateErr).AnyTimes()
 
 			u := NewEventUsecase(mockUserService, mockEventRepository)
 
@@ -148,7 +148,7 @@ func TestGetEvent(t *testing.T) {
 			mockEvent := mocksevent.NewMockEvent(ctrl)
 			mockEvent.EXPECT().UserID().Return(domainuser.UserID{UUID: uuid.MustParse(tt.eventUserID)}).AnyTimes()
 			mockEventRepository := mocksevent.NewMockEventRepository(ctrl)
-			mockEventRepository.EXPECT().FindByID(gomock.Any(), gomock.Any()).Return(mockEvent, tt.findByIDErr).AnyTimes()
+			mockEventRepository.EXPECT().FindByID(tt.ctx, gomock.Any()).Return(mockEvent, tt.findByIDErr).AnyTimes()
 
 			u := NewEventUsecase(mockUserService, mockEventRepository)
 
@@ -190,7 +190,7 @@ func TestListEvents(t *testing.T) {
 			mockUserService.EXPECT().GetUser(tt.ctx).Return(tt.userID, tt.getUserErr).AnyTimes()
 			mockEvent := mocksevent.NewMockEvent(ctrl)
 			mockEventRepository := mocksevent.NewMockEventRepository(ctrl)
-			mockEventRepository.EXPECT().FindAllByUserID(gomock.Any(), gomock.Any()).Return([]event.Event{mockEvent}, tt.findAllByUserIDErr).AnyTimes()
+			mockEventRepository.EXPECT().FindAllByUserID(tt.ctx, gomock.Any()).Return([]event.Event{mockEvent}, tt.findAllByUserIDErr).AnyTimes()
 
 			u := NewEventUsecase(mockUserService, mockEventRepository)
 
@@ -237,8 +237,8 @@ func TestDeleteEvent(t *testing.T) {
 			mockEvent := mocksevent.NewMockEvent(ctrl)
 			mockEvent.EXPECT().UserID().Return(domainuser.UserID{UUID: uuid.MustParse(tt.eventUserID)}).AnyTimes()
 			mockEventRepository := mocksevent.NewMockEventRepository(ctrl)
-			mockEventRepository.EXPECT().FindByID(gomock.Any(), gomock.Any()).Return(mockEvent, tt.findByIDErr).AnyTimes()
-			mockEventRepository.EXPECT().Delete(gomock.Any(), gomock.Any()).Return(tt.deleteErr).AnyTimes()
+			mockEventRepository.EXPECT().FindByID(tt.ctx, gomock.Any()).Return(mockEvent, tt.findByIDErr).AnyTimes()
+			mockEventRepository.EXPECT().Delete(tt.ctx, gomock.Any()).Return(tt.deleteErr).AnyTimes()
 
 			u := NewEventUsecase(mockUserService, mockEventRepository)
 

--- a/internal/application/event/usecase_test.go
+++ b/internal/application/event/usecase_test.go
@@ -48,7 +48,7 @@ func TestCreateEvent(t *testing.T) {
 			mockUserService := mocksuser.NewMockUserService(ctrl)
 			mockEventRepository := mocksevent.NewMockEventRepository(ctrl)
 			mockUserService.EXPECT().GetUser(tt.ctx).Return(tt.userID, tt.getUserErr).AnyTimes()
-			mockEventRepository.EXPECT().Create(gomock.Any()).Return(tt.createErr).AnyTimes()
+			mockEventRepository.EXPECT().Create(gomock.Any(), gomock.Any()).Return(tt.createErr).AnyTimes()
 
 			u := NewEventUsecase(mockUserService, mockEventRepository)
 
@@ -102,8 +102,8 @@ func TestUpdateEvent(t *testing.T) {
 			mockEvent.EXPECT().EndTime().Return(now).AnyTimes()
 			mockEvent.EXPECT().Update(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return().AnyTimes()
 			mockEventRepository := mocksevent.NewMockEventRepository(ctrl)
-			mockEventRepository.EXPECT().FindByID(gomock.Any()).Return(mockEvent, tt.findByIDErr).AnyTimes()
-			mockEventRepository.EXPECT().Update(gomock.Any()).Return(tt.updateErr).AnyTimes()
+			mockEventRepository.EXPECT().FindByID(gomock.Any(), gomock.Any()).Return(mockEvent, tt.findByIDErr).AnyTimes()
+			mockEventRepository.EXPECT().Update(gomock.Any(), gomock.Any()).Return(tt.updateErr).AnyTimes()
 
 			u := NewEventUsecase(mockUserService, mockEventRepository)
 
@@ -148,7 +148,7 @@ func TestGetEvent(t *testing.T) {
 			mockEvent := mocksevent.NewMockEvent(ctrl)
 			mockEvent.EXPECT().UserID().Return(domainuser.UserID{UUID: uuid.MustParse(tt.eventUserID)}).AnyTimes()
 			mockEventRepository := mocksevent.NewMockEventRepository(ctrl)
-			mockEventRepository.EXPECT().FindByID(gomock.Any()).Return(mockEvent, tt.findByIDErr).AnyTimes()
+			mockEventRepository.EXPECT().FindByID(gomock.Any(), gomock.Any()).Return(mockEvent, tt.findByIDErr).AnyTimes()
 
 			u := NewEventUsecase(mockUserService, mockEventRepository)
 
@@ -190,7 +190,7 @@ func TestListEvents(t *testing.T) {
 			mockUserService.EXPECT().GetUser(tt.ctx).Return(tt.userID, tt.getUserErr).AnyTimes()
 			mockEvent := mocksevent.NewMockEvent(ctrl)
 			mockEventRepository := mocksevent.NewMockEventRepository(ctrl)
-			mockEventRepository.EXPECT().FindAllByUserID(gomock.Any()).Return([]event.Event{mockEvent}, tt.findAllByUserIDErr).AnyTimes()
+			mockEventRepository.EXPECT().FindAllByUserID(gomock.Any(), gomock.Any()).Return([]event.Event{mockEvent}, tt.findAllByUserIDErr).AnyTimes()
 
 			u := NewEventUsecase(mockUserService, mockEventRepository)
 
@@ -237,8 +237,8 @@ func TestDeleteEvent(t *testing.T) {
 			mockEvent := mocksevent.NewMockEvent(ctrl)
 			mockEvent.EXPECT().UserID().Return(domainuser.UserID{UUID: uuid.MustParse(tt.eventUserID)}).AnyTimes()
 			mockEventRepository := mocksevent.NewMockEventRepository(ctrl)
-			mockEventRepository.EXPECT().FindByID(gomock.Any()).Return(mockEvent, tt.findByIDErr).AnyTimes()
-			mockEventRepository.EXPECT().Delete(gomock.Any()).Return(tt.deleteErr).AnyTimes()
+			mockEventRepository.EXPECT().FindByID(gomock.Any(), gomock.Any()).Return(mockEvent, tt.findByIDErr).AnyTimes()
+			mockEventRepository.EXPECT().Delete(gomock.Any(), gomock.Any()).Return(tt.deleteErr).AnyTimes()
 
 			u := NewEventUsecase(mockUserService, mockEventRepository)
 

--- a/internal/domain/event/repository.go
+++ b/internal/domain/event/repository.go
@@ -1,11 +1,15 @@
 package event
 
-import "github.com/qkitzero/event-service/internal/domain/user"
+import (
+	"context"
+
+	"github.com/qkitzero/event-service/internal/domain/user"
+)
 
 type EventRepository interface {
-	Create(event Event) error
-	Update(event Event) error
-	FindByID(id EventID) (Event, error)
-	FindAllByUserID(userID user.UserID) ([]Event, error)
-	Delete(id EventID) error
+	Create(ctx context.Context, event Event) error
+	Update(ctx context.Context, event Event) error
+	FindByID(ctx context.Context, id EventID) (Event, error)
+	FindAllByUserID(ctx context.Context, userID user.UserID) ([]Event, error)
+	Delete(ctx context.Context, id EventID) error
 }

--- a/internal/infrastructure/event/repository.go
+++ b/internal/infrastructure/event/repository.go
@@ -1,6 +1,7 @@
 package event
 
 import (
+	"context"
 	"errors"
 
 	"gorm.io/gorm"
@@ -17,8 +18,8 @@ func NewEventRepository(db *gorm.DB) event.EventRepository {
 	return &eventRepository{db: db}
 }
 
-func (r *eventRepository) Create(e event.Event) error {
-	return r.db.Transaction(func(tx *gorm.DB) error {
+func (r *eventRepository) Create(ctx context.Context, e event.Event) error {
+	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		eventModel := EventModel{
 			ID:          e.ID(),
 			UserID:      e.UserID(),
@@ -39,8 +40,8 @@ func (r *eventRepository) Create(e event.Event) error {
 	})
 }
 
-func (r *eventRepository) Update(e event.Event) error {
-	return r.db.Transaction(func(tx *gorm.DB) error {
+func (r *eventRepository) Update(ctx context.Context, e event.Event) error {
+	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		eventModel := EventModel{
 			ID:          e.ID(),
 			UserID:      e.UserID(),
@@ -61,9 +62,9 @@ func (r *eventRepository) Update(e event.Event) error {
 	})
 }
 
-func (r *eventRepository) FindByID(id event.EventID) (event.Event, error) {
+func (r *eventRepository) FindByID(ctx context.Context, id event.EventID) (event.Event, error) {
 	var eventModel EventModel
-	err := r.db.First(&eventModel, "id = ?", id).Error
+	err := r.db.WithContext(ctx).First(&eventModel, "id = ?", id).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		return nil, event.ErrEventNotFound
 	}
@@ -86,9 +87,9 @@ func (r *eventRepository) FindByID(id event.EventID) (event.Event, error) {
 	return e, nil
 }
 
-func (r *eventRepository) FindAllByUserID(userID user.UserID) ([]event.Event, error) {
+func (r *eventRepository) FindAllByUserID(ctx context.Context, userID user.UserID) ([]event.Event, error) {
 	var eventModels []EventModel
-	if err := r.db.Where("user_id = ?", userID).Order("start_time asc, end_time asc").Find(&eventModels).Error; err != nil {
+	if err := r.db.WithContext(ctx).Where("user_id = ?", userID).Order("start_time asc, end_time asc").Find(&eventModels).Error; err != nil {
 		return nil, err
 	}
 
@@ -111,8 +112,8 @@ func (r *eventRepository) FindAllByUserID(userID user.UserID) ([]event.Event, er
 	return events, nil
 }
 
-func (r *eventRepository) Delete(id event.EventID) error {
-	return r.db.Transaction(func(tx *gorm.DB) error {
+func (r *eventRepository) Delete(ctx context.Context, id event.EventID) error {
+	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		if err := tx.Delete(&EventModel{}, "id = ?", id).Error; err != nil {
 			return err
 		}

--- a/internal/infrastructure/event/repository_test.go
+++ b/internal/infrastructure/event/repository_test.go
@@ -1,6 +1,7 @@
 package event
 
 import (
+	"context"
 	"errors"
 	"regexp"
 	"testing"
@@ -85,7 +86,7 @@ func TestCreate(t *testing.T) {
 
 			repo := NewEventRepository(gormDB)
 
-			err = repo.Create(mockEvent)
+			err = repo.Create(context.Background(), mockEvent)
 			if tt.success && err != nil {
 				t.Errorf("expected no error, but got %v", err)
 			}
@@ -167,7 +168,7 @@ func TestUpdate(t *testing.T) {
 
 			repo := NewEventRepository(gormDB)
 
-			err = repo.Update(mockEvent)
+			err = repo.Update(context.Background(), mockEvent)
 			if tt.success && err != nil {
 				t.Errorf("expected no error, but got %v", err)
 			}
@@ -245,7 +246,7 @@ func TestFindByID(t *testing.T) {
 
 			repo := NewEventRepository(gormDB)
 
-			_, err = repo.FindByID(tt.id)
+			_, err = repo.FindByID(context.Background(), tt.id)
 			if tt.success && err != nil {
 				t.Errorf("expected no error, but got %v", err)
 			}
@@ -313,7 +314,7 @@ func TestFindAllByUserID(t *testing.T) {
 
 			repo := NewEventRepository(gormDB)
 
-			_, err = repo.FindAllByUserID(tt.userID)
+			_, err = repo.FindAllByUserID(context.Background(), tt.userID)
 			if tt.success && err != nil {
 				t.Errorf("expected no error, but got %v", err)
 			}
@@ -387,7 +388,7 @@ func TestDelete(t *testing.T) {
 
 			repo := NewEventRepository(gormDB)
 
-			err = repo.Delete(tt.id)
+			err = repo.Delete(context.Background(), tt.id)
 			if tt.success && err != nil {
 				t.Errorf("expected no error, but got %v", err)
 			}

--- a/mocks/domain/event/mock_repository.go
+++ b/mocks/domain/event/mock_repository.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	event "github.com/qkitzero/event-service/internal/domain/event"
@@ -42,73 +43,73 @@ func (m *MockEventRepository) EXPECT() *MockEventRepositoryMockRecorder {
 }
 
 // Create mocks base method.
-func (m *MockEventRepository) Create(arg0 event.Event) error {
+func (m *MockEventRepository) Create(ctx context.Context, arg1 event.Event) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Create", arg0)
+	ret := m.ctrl.Call(m, "Create", ctx, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Create indicates an expected call of Create.
-func (mr *MockEventRepositoryMockRecorder) Create(arg0 any) *gomock.Call {
+func (mr *MockEventRepositoryMockRecorder) Create(ctx, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockEventRepository)(nil).Create), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockEventRepository)(nil).Create), ctx, arg1)
 }
 
 // Delete mocks base method.
-func (m *MockEventRepository) Delete(id event.EventID) error {
+func (m *MockEventRepository) Delete(ctx context.Context, id event.EventID) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", id)
+	ret := m.ctrl.Call(m, "Delete", ctx, id)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockEventRepositoryMockRecorder) Delete(id any) *gomock.Call {
+func (mr *MockEventRepositoryMockRecorder) Delete(ctx, id any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockEventRepository)(nil).Delete), id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockEventRepository)(nil).Delete), ctx, id)
 }
 
 // FindAllByUserID mocks base method.
-func (m *MockEventRepository) FindAllByUserID(userID user.UserID) ([]event.Event, error) {
+func (m *MockEventRepository) FindAllByUserID(ctx context.Context, userID user.UserID) ([]event.Event, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindAllByUserID", userID)
+	ret := m.ctrl.Call(m, "FindAllByUserID", ctx, userID)
 	ret0, _ := ret[0].([]event.Event)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FindAllByUserID indicates an expected call of FindAllByUserID.
-func (mr *MockEventRepositoryMockRecorder) FindAllByUserID(userID any) *gomock.Call {
+func (mr *MockEventRepositoryMockRecorder) FindAllByUserID(ctx, userID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindAllByUserID", reflect.TypeOf((*MockEventRepository)(nil).FindAllByUserID), userID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindAllByUserID", reflect.TypeOf((*MockEventRepository)(nil).FindAllByUserID), ctx, userID)
 }
 
 // FindByID mocks base method.
-func (m *MockEventRepository) FindByID(id event.EventID) (event.Event, error) {
+func (m *MockEventRepository) FindByID(ctx context.Context, id event.EventID) (event.Event, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindByID", id)
+	ret := m.ctrl.Call(m, "FindByID", ctx, id)
 	ret0, _ := ret[0].(event.Event)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FindByID indicates an expected call of FindByID.
-func (mr *MockEventRepositoryMockRecorder) FindByID(id any) *gomock.Call {
+func (mr *MockEventRepositoryMockRecorder) FindByID(ctx, id any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindByID", reflect.TypeOf((*MockEventRepository)(nil).FindByID), id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindByID", reflect.TypeOf((*MockEventRepository)(nil).FindByID), ctx, id)
 }
 
 // Update mocks base method.
-func (m *MockEventRepository) Update(arg0 event.Event) error {
+func (m *MockEventRepository) Update(ctx context.Context, arg1 event.Event) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Update", arg0)
+	ret := m.ctrl.Call(m, "Update", ctx, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Update indicates an expected call of Update.
-func (mr *MockEventRepositoryMockRecorder) Update(arg0 any) *gomock.Call {
+func (mr *MockEventRepositoryMockRecorder) Update(ctx, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockEventRepository)(nil).Update), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockEventRepository)(nil).Update), ctx, arg1)
 }


### PR DESCRIPTION
## Summary
- Add `ctx context.Context` as the first argument of every method on `EventRepository`
- Update the GORM implementation to call `r.db.WithContext(ctx)` (including inside `Transaction`)
- Propagate the handler `ctx` through `internal/application/event/usecase.go` to the repository
- Regenerate mocks; update test call sites to pass `context.Background()`

Closes #91.

## Notes
- Mirrors the pattern from [workout-service#16](https://github.com/qkitzero/workout-service/pull/16) (commit `update: propagate context through repositories`)
- Out of scope: handler-level deadlines, OpenTelemetry — this PR only wires the plumbing

## Test plan
- [x] `go test ./...` passes
- [x] `make mock-gen` produces clean mocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)